### PR TITLE
Make background and ripple animation behave the same in all supporting c...

### DIFF
--- a/Source/MKButton.swift
+++ b/Source/MKButton.swift
@@ -40,7 +40,8 @@ public class MKButton : UIButton
             }
         }
     }
-    @IBInspectable public var aniDuration: Float = 0.65
+    @IBInspectable public var rippleAniDuration: Float = 0.75
+    @IBInspectable public var backgroundAniDuration: Float = 1.0
     @IBInspectable public var rippleAniTimingFunction: MKTimingFunction = .Linear
     @IBInspectable public var backgroundAniTimingFunction: MKTimingFunction = .Linear
     @IBInspectable public var shadowAniTimingFunction: MKTimingFunction = .EaseOut
@@ -96,11 +97,11 @@ public class MKButton : UIButton
         }
 
         // rippleLayer animation
-        mkLayer.animateScaleForCircleLayer(0.45, toScale: 1.0, timingFunction: rippleAniTimingFunction, duration: CFTimeInterval(aniDuration))
+        mkLayer.animateScaleForCircleLayer(0.45, toScale: 1.0, timingFunction: rippleAniTimingFunction, duration: CFTimeInterval(self.rippleAniDuration))
 
         // backgroundLayer animation
         if backgroundAniEnabled {
-            mkLayer.animateAlphaForBackgroundLayer(backgroundAniTimingFunction, duration: CFTimeInterval(aniDuration))
+            mkLayer.animateAlphaForBackgroundLayer(backgroundAniTimingFunction, duration: CFTimeInterval(self.backgroundAniDuration))
         }
 
         // shadow animation for self

--- a/Source/MKButton.swift
+++ b/Source/MKButton.swift
@@ -44,6 +44,7 @@ public class MKButton : UIButton
     @IBInspectable public var backgroundAniDuration: Float = 1.0
     @IBInspectable public var rippleAniTimingFunction: MKTimingFunction = .Linear
     @IBInspectable public var backgroundAniTimingFunction: MKTimingFunction = .Linear
+    @IBInspectable public var shadowAniDuration: Float = 0.65
     @IBInspectable public var shadowAniTimingFunction: MKTimingFunction = .EaseOut
 
     @IBInspectable public var cornerRadius: CGFloat = 2.5 {
@@ -112,7 +113,7 @@ public class MKButton : UIButton
             //if mkType == .Flat {
             //    mkLayer.animateMaskLayerShadow()
             //} else {
-                mkLayer.animateSuperLayerShadow(10, toRadius: shadowRadius, fromOpacity: 0, toOpacity: shadowOpacity, timingFunction: shadowAniTimingFunction, duration: CFTimeInterval(aniDuration))
+                mkLayer.animateSuperLayerShadow(10, toRadius: shadowRadius, fromOpacity: 0, toOpacity: shadowOpacity, timingFunction: shadowAniTimingFunction, duration: CFTimeInterval(shadowAniDuration))
             //}
         }
 

--- a/Source/MKImageView.swift
+++ b/Source/MKImageView.swift
@@ -21,7 +21,8 @@ public class MKImageView: UIImageView
             mkLayer.rippleLocation = rippleLocation
         }
     }
-    @IBInspectable public var aniDuration: Float = 0.65
+    @IBInspectable public var rippleAniDuration: Float = 0.75
+    @IBInspectable public var backgroundAniDuration: Float = 1.0
     @IBInspectable public var rippleAniTimingFunction: MKTimingFunction = .Linear
     @IBInspectable public var backgroundAniTimingFunction: MKTimingFunction = .Linear
     @IBInspectable public var backgroundAniEnabled: Bool = true {
@@ -99,8 +100,8 @@ public class MKImageView: UIImageView
             rippleLocation = .Center
         }
 
-        mkLayer.animateScaleForCircleLayer(0.65, toScale: 1.0, timingFunction: rippleAniTimingFunction, duration: CFTimeInterval(aniDuration))
-        mkLayer.animateAlphaForBackgroundLayer(backgroundAniTimingFunction, duration: CFTimeInterval(aniDuration))
+        mkLayer.animateScaleForCircleLayer(0.65, toScale: 1.0, timingFunction: rippleAniTimingFunction, duration: CFTimeInterval(self.rippleAniDuration))
+        mkLayer.animateAlphaForBackgroundLayer(backgroundAniTimingFunction, duration: CFTimeInterval(self.backgroundAniDuration))
     }
 
     override public func touchesBegan(touches: NSSet, withEvent event: UIEvent) {

--- a/Source/MKLabel.swift
+++ b/Source/MKLabel.swift
@@ -19,7 +19,8 @@ public class MKLabel: UILabel {
             mkLayer.rippleLocation = rippleLocation
         }
     }
-    @IBInspectable public var aniDuration: Float = 0.65
+    @IBInspectable public var rippleAniDuration: Float = 0.75
+    @IBInspectable public var backgroundAniDuration: Float = 1.0
     @IBInspectable public var rippleAniTimingFunction: MKTimingFunction = .Linear
     @IBInspectable public var backgroundAniTimingFunction: MKTimingFunction = .Linear
     @IBInspectable public var backgroundAniEnabled: Bool = true {
@@ -87,8 +88,8 @@ public class MKLabel: UILabel {
             rippleLocation = .Center
         }
 
-        mkLayer.animateScaleForCircleLayer(0.65, toScale: 1.0, timingFunction: rippleAniTimingFunction, duration: CFTimeInterval(aniDuration))
-        mkLayer.animateAlphaForBackgroundLayer(backgroundAniTimingFunction, duration: CFTimeInterval(aniDuration))
+        mkLayer.animateScaleForCircleLayer(0.65, toScale: 1.0, timingFunction: rippleAniTimingFunction, duration: CFTimeInterval(self.rippleAniDuration))
+        mkLayer.animateAlphaForBackgroundLayer(backgroundAniTimingFunction, duration: CFTimeInterval(self.backgroundAniDuration))
     }
 
     override public func touchesBegan(touches: NSSet, withEvent event: UIEvent) {

--- a/Source/MKTextField.swift
+++ b/Source/MKTextField.swift
@@ -21,7 +21,8 @@ public class MKTextField : UITextField {
         }
     }
 
-    @IBInspectable public var aniDuration: Float = 0.65
+    @IBInspectable public var rippleAniDuration: Float = 0.75
+    @IBInspectable public var backgroundAniDuration: Float = 1.0
     @IBInspectable public var rippleAniTimingFunction: MKTimingFunction = .Linear
     @IBInspectable public var shadowAniEnabled: Bool = true
     @IBInspectable public var cornerRadius: CGFloat = 2.5 {
@@ -41,6 +42,7 @@ public class MKTextField : UITextField {
             mkLayer.setBackgroundLayerColor(backgroundLayerColor)
         }
     }
+    
 
     // floating label
     @IBInspectable public var floatingLabelFont: UIFont = UIFont.boldSystemFontOfSize(10.0) {
@@ -115,8 +117,8 @@ public class MKTextField : UITextField {
     override public func beginTrackingWithTouch(touch: UITouch, withEvent event: UIEvent) -> Bool {
         mkLayer.didChangeTapLocation(touch.locationInView(self))
 
-        mkLayer.animateScaleForCircleLayer(0.45, toScale: 1.0, timingFunction: MKTimingFunction.Linear, duration: 0.75)
-        mkLayer.animateAlphaForBackgroundLayer(MKTimingFunction.Linear, duration: 0.75)
+        mkLayer.animateScaleForCircleLayer(0.45, toScale: 1.0, timingFunction: MKTimingFunction.Linear, duration: CFTimeInterval(self.rippleAniDuration))
+        mkLayer.animateAlphaForBackgroundLayer(MKTimingFunction.Linear, duration: CFTimeInterval(self.backgroundAniDuration))
 
         return super.beginTrackingWithTouch(touch, withEvent: event)
     }


### PR DESCRIPTION
Changes done:
 - __MKButton__: `aniDuration` was split into `rippleAniDuration` and `backgroundAniDuration` and `shadowAniDuration` for more individual configuration
 - __MKImageView__: `aniDuration` was split into `rippleAniDuration` and `backgroundAniDuration` for more individual configuration
 - __MKLabel__: `aniDuration` was split into `rippleAniDuration` and `backgroundAniDuration` for more individual configuration
 - __MKTextField__: didn't use `aniDuration`. It was replaced with `rippleAniDuration` and `backgroundAniDuration` for more individual configuration and the variables are now used in the same way as in the above classes

In my opinion this provides a more consistent way of individualizing this awesome UI Components