### PR TITLE
Placeholder text can now be set within interface builder.

### DIFF
--- a/Source/MKTextField.swift
+++ b/Source/MKTextField.swift
@@ -72,9 +72,7 @@ public class MKTextField : UITextField {
 
     override public var placeholder: String? {
         didSet {
-            floatingLabel.text = placeholder
-            floatingLabel.sizeToFit()
-            setFloatingLabelOverlapTextField()
+            self.setFloatingLabelTextToPlaceholderText()
         }
     }
     override public var bounds: CGRect {
@@ -109,6 +107,7 @@ public class MKTextField : UITextField {
         floatingLabel = UILabel()
         floatingLabel.font = floatingLabelFont
         floatingLabel.alpha = 0.0
+        self.setFloatingLabelTextToPlaceholderText()
         addSubview(floatingLabel)
     }
 
@@ -189,5 +188,11 @@ public class MKTextField : UITextField {
 
     private func hideFloatingLabel() {
         floatingLabel.alpha = 0.0
+    }
+    
+    private func setFloatingLabelTextToPlaceholderText() {
+        floatingLabel.text = placeholder
+        floatingLabel.sizeToFit()
+        setFloatingLabelOverlapTextField()
     }
 }


### PR DESCRIPTION
This fixes an issue where the floating label does not get it's text set from the placeholder text in interface builder.

Extracted the text setting, sizing, and positioning to a private method that is called during setup.