### PR TITLE
Add removeAllAnimations() function to MKLayer.

### DIFF
--- a/Example/MaterialKit/TableViewController.swift
+++ b/Example/MaterialKit/TableViewController.swift
@@ -18,7 +18,7 @@ class TableViewController: UIViewController, UITableViewDelegate, UITableViewDat
     }
     
     func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return labels.count
+        return 100
     }
     
     func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
@@ -27,8 +27,8 @@ class TableViewController: UIViewController, UITableViewDelegate, UITableViewDat
     
     func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         var cell = tableView.dequeueReusableCellWithIdentifier("MyCell") as! MyCell
-        cell.setMessage(labels[indexPath.row])
-        cell.rippleLocation = rippleLocations[indexPath.row]
+        cell.setMessage(labels[indexPath.row % labels.count])
+        cell.rippleLocation = rippleLocations[indexPath.row % labels.count]
         
         let index = indexPath.row % circleColors.count
         cell.rippleLayerColor = circleColors[index]

--- a/Source/MKLayer.swift
+++ b/Source/MKLayer.swift
@@ -215,4 +215,10 @@ public class MKLayer {
 
         layer.addAnimation(groupAnimation, forKey: nil)
     }
+    
+    public func removeAllAnimations() {
+        self.backgroundLayer.removeAllAnimations()
+        self.rippleLayer.removeAllAnimations()
+    }
+    
 }

--- a/Source/MKTableViewCell.swift
+++ b/Source/MKTableViewCell.swift
@@ -50,6 +50,10 @@ public class MKTableViewCell : UITableViewCell {
         mkLayer.ripplePercent = 1.2
     }
 
+    public override func prepareForReuse() {
+        super.prepareForReuse()
+        self.mkLayer.removeAllAnimations()
+    }
     
     override public func touchesBegan(touches: Set<NSObject>, withEvent event: UIEvent) {
         super.touchesBegan(touches, withEvent: event)


### PR DESCRIPTION
I have added a removeAllAnimations() function to MKLayer which removes animations for the circle layer and background layer.

This is particularly useful in prepareForReuse() on MKTableViewCell so that previous animations do not show on scroll.

I added cells to the table view example in order to show this behavior.